### PR TITLE
Remove Java 8 build from CI

### DIFF
--- a/.circleci/continue-workflows.yml
+++ b/.circleci/continue-workflows.yml
@@ -130,9 +130,6 @@ workflows:
         - << pipeline.parameters.updated-sdk >>
     jobs:
       - build-sdk:
-          name: Build with OpenJDK 8
-          docker-image: cimg/openjdk:8.0
-      - build-sdk:
           name: Build with OpenJDK 11
           docker-image: cimg/openjdk:11.0
       - build-sdk:


### PR DESCRIPTION
Not required for now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture-java/18)
<!-- Reviewable:end -->
